### PR TITLE
Move value check to factory

### DIFF
--- a/NimbleConfig.Core/ConfigurationReaders/ComplexTypeConfigurationReader.cs
+++ b/NimbleConfig.Core/ConfigurationReaders/ComplexTypeConfigurationReader.cs
@@ -1,34 +1,24 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using NimbleConfig.Core.Configuration;
-using NimbleConfig.Core.Exceptions;
 using NimbleConfig.Core.Logging;
-using NimbleConfig.Core.Options;
 
 namespace NimbleConfig.Core.ConfigurationReaders
 {
-    public class ComplexTypeConfigurationReader : IConfigurationReader
+    public class ComplexTypeConfigurationReader : ConfigurationReader
     {
-        public object Read(IConfiguration configuration, Type complexType, IKeyName keyName, MissingConfigurationStratergy configurationStratergy)
+        public override object Read(IConfiguration configuration, Type complexType, IKeyName keyName)
         {
             var key = keyName.QualifiedKeyName;
 
             // return null if no section exists
-            if (!configuration.GetSection(key).Exists())
+            if (!ValueExists(configuration, complexType, keyName))
             {
                 StaticLoggingHelper.Warning($"No configuration for '{key}' was found.");
-
-                if (configurationStratergy == MissingConfigurationStratergy.ThrowException)
-                {
-                    throw new ConfigurationSettingMissingException(complexType, keyName);
-                }
-
                 return null;
             }
-            else
-            {
-                return configuration.GetSection(key).Get(complexType);
-            }
+
+            return configuration.GetSection(key).Get(complexType);
         }
     }
 }

--- a/NimbleConfig.Core/ConfigurationReaders/ConfigurationReader.cs
+++ b/NimbleConfig.Core/ConfigurationReaders/ConfigurationReader.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+using NimbleConfig.Core.Configuration;
+
+namespace NimbleConfig.Core.ConfigurationReaders
+{
+    public abstract class ConfigurationReader: IConfigurationReader
+    {
+        public abstract object Read(IConfiguration configuration, Type configType, IKeyName keyName);
+
+        public bool ValueExists(IConfiguration configuration, Type configType, IKeyName keyName)
+        {
+            var key = keyName.QualifiedKeyName;
+            return configuration.GetSection(key).Exists();
+        }
+    }
+}

--- a/NimbleConfig.Core/ConfigurationReaders/GenericNonValueTypeConfigurationReader.cs
+++ b/NimbleConfig.Core/ConfigurationReaders/GenericNonValueTypeConfigurationReader.cs
@@ -2,16 +2,14 @@
 using System.Linq;
 using Microsoft.Extensions.Configuration;
 using NimbleConfig.Core.Configuration;
-using NimbleConfig.Core.Exceptions;
 using NimbleConfig.Core.Extensions;
 using NimbleConfig.Core.Logging;
-using NimbleConfig.Core.Options;
 
 namespace NimbleConfig.Core.ConfigurationReaders
 {
-    public class GenericNonValueTypeConfigurationReader: IConfigurationReader
+    public class GenericNonValueTypeConfigurationReader: ConfigurationReader
     {
-        public object Read(IConfiguration configuration, Type configType, IKeyName keyName, MissingConfigurationStratergy configurationStratergy)
+        public override object Read(IConfiguration configuration, Type configType, IKeyName keyName)
         {
             var valueType = configType.GetGenericTypeOfConfigurationSetting();
             var elementType = valueType.GetElementType();
@@ -22,11 +20,6 @@ namespace NimbleConfig.Core.ConfigurationReaders
             {
                 // Return null if no section exists
                 StaticLoggingHelper.Warning($"No configuration for '{key}' was found.");
-
-                if (configurationStratergy == MissingConfigurationStratergy.ThrowException)
-                {
-                    throw new ConfigurationSettingMissingException(configType, keyName);
-                }
 
                 return null;
             }

--- a/NimbleConfig.Core/ConfigurationReaders/GenericValueTypeConfigurationReader.cs
+++ b/NimbleConfig.Core/ConfigurationReaders/GenericValueTypeConfigurationReader.cs
@@ -1,31 +1,23 @@
 ﻿using System;
 using Microsoft.Extensions.Configuration;
 using NimbleConfig.Core.Configuration;
-using NimbleConfig.Core.Exceptions;
 using NimbleConfig.Core.Extensions;
 using NimbleConfig.Core.Logging;
-using NimbleConfig.Core.Options;
 
 namespace NimbleConfig.Core.ConfigurationReaders
 {
-    public class GenericValueTypeConfigurationReader : IConfigurationReader
+    public class GenericValueTypeConfigurationReader : ConfigurationReader
     {
-        public object Read(IConfiguration configuration, Type configType, IKeyName keyName, MissingConfigurationStratergy configurationStratergy)
+        public override object Read(IConfiguration configuration, Type configType, IKeyName keyName)
         {
             var key = keyName.QualifiedKeyName;
             var valueType = configType.GetGenericTypeOfConfigurationSetting();
 
             // Making sure the section exists
-            if (!configuration.GetSection(key).Exists())
+            if (!ValueExists(configuration, configType, keyName))
             {
                 // Return default value if no section exists
                 StaticLoggingHelper.Warning($"No configuration for '{key}' was found.");
-
-                if (configurationStratergy == MissingConfigurationStratergy.ThrowException)
-                {
-                    throw new ConfigurationSettingMissingException(configType, keyName);
-                }
-
                 return GetDefault(valueType);
             }
 

--- a/NimbleConfig.Core/ConfigurationReaders/IConfigurationReader.cs
+++ b/NimbleConfig.Core/ConfigurationReaders/IConfigurationReader.cs
@@ -9,7 +9,10 @@ namespace NimbleConfig.Core.ConfigurationReaders
     {
         object Read(IConfiguration configuration,
             Type configType,
-            IKeyName keyName,
-            MissingConfigurationStratergy configurationStratergy);
+            IKeyName keyName);
+
+        bool ValueExists(IConfiguration configuration,
+            Type configType,
+            IKeyName keyName);
     }
 }

--- a/NimbleConfig.Core/Factory/ConfigurationFactory.cs
+++ b/NimbleConfig.Core/Factory/ConfigurationFactory.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Configuration;
 using NimbleConfig.Core.Configuration;
 using NimbleConfig.Core.ConfigurationReaders;
+using NimbleConfig.Core.Exceptions;
 using NimbleConfig.Core.Extensions;
 using NimbleConfig.Core.Logging;
 using NimbleConfig.Core.Options;
@@ -68,9 +69,16 @@ namespace NimbleConfig.Core.Factory
                 reader.EnsureNotNull(nameof(IConfigurationReader));
                 parser.EnsureNotNull(nameof(IParser));
                 valueConstructor.EnsureNotNull(nameof(IValueConstructor));
+                
+                // Throw exception if missing configuration is required
+                if (_configurationOptions.MissingConfigurationStratergy == MissingConfigurationStratergy.ThrowException
+                    && !reader.ValueExists(_configuration, configType, keyName))
+                {
+                    throw new ConfigurationSettingMissingException(configType, keyName);
+                }
 
                 // Read and parse the value
-                var rawValue = reader.Read(_configuration, configType, keyName, _configurationOptions.MissingConfigurationStratergy);
+                var rawValue = reader.Read(_configuration, configType, keyName);
                 var value = parser.Parse(configType, rawValue);
 
                 // Set the value


### PR DESCRIPTION
The existing configuration readers throw an exception if a setting is missing from the config and the strategy is defined t throw. But this logic is hidden away inside the read method.

- Move the exception throwing logic to the factory
- Introduce a ValueExists() method for IConfigurationReader so the factory can still use the config reader of choice.