### PR TITLE
Add implict operator for ConfigurationSetting

### DIFF
--- a/NimbleConfig.Core.Tests/GenericTypeSettingTests.cs
+++ b/NimbleConfig.Core.Tests/GenericTypeSettingTests.cs
@@ -91,6 +91,13 @@ namespace NimbleConfig.Core.Tests
             SomeUnresolvedSetting config = _configurationFactory.CreateConfigurationSetting(typeof(SomeUnresolvedSetting));
             string.IsNullOrEmpty(config.Value).ShouldBeTrue();
         }
+        
+        [Fact]
+        public void ImplicitConversionShouldBeTheSameAsValue()
+        {
+            SomeIntSetting config = _configurationFactory.CreateConfigurationSetting(typeof(SomeIntSetting));
+            config.Value.ShouldBe(config);
+        }
 
         [Fact]
         public void MissingStringSettingThrowsException()

--- a/NimbleConfig.Core/Configuration/ConfigurationSetting.cs
+++ b/NimbleConfig.Core/Configuration/ConfigurationSetting.cs
@@ -21,6 +21,8 @@ namespace NimbleConfig.Core.Configuration
 
             Value = value;
         }
+        
+        public static implicit operator TValue(ConfigurationSetting<TValue> d) => d.Value;
     }
 
 }


### PR DESCRIPTION
This is to allow settings to be passed to where they are wanted to be used the same as IComplexConfigurationSetting without having to access the `.Value` property.